### PR TITLE
多重にFlowオブジェクトを生成していた問題を修正

### DIFF
--- a/app/src/main/java/com/tfandkusu/observeroom/view/main/MainActivity.kt
+++ b/app/src/main/java/com/tfandkusu/observeroom/view/main/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
                 list.scrollToPosition(it)
             }
         })
-        viewModel.onCreate(this, savedInstanceState?.getInt(EXTRA_SCROLL))
+        viewModel.onCreate(this, savedInstanceState?.getInt(EXTRA_SCROLL) ?: 0)
     }
 
     /**

--- a/app/src/main/java/com/tfandkusu/observeroom/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/tfandkusu/observeroom/view/main/MainViewModel.kt
@@ -95,15 +95,17 @@ class MainViewModel(private val localDataStore: MemberLocalDataStore) : ViewMode
                         if (firstTime) {
                             // 最初の1回だけ実行する
                             firstTime = false
-                            val flow = localDataStore.listMembersCoroutineFlow()
-                            flow.collect {
-                                items.value = it.map { src ->
+                            val flow = localDataStore.listMembersCoroutineFlow().map { list ->
+                                list.map {
                                     MemberListItem(
-                                        src.member.id,
-                                        src.member.name,
-                                        src.division.name
+                                        it.member.id,
+                                        it.member.name,
+                                        it.division.name
                                     )
                                 }
+                            }
+                            flow.collect {
+                                items.value = it
                                 // 読み込み完了
                                 progress.value = false
                                 Log.d("ObserveRoom", "flow.collect")

--- a/app/src/test/java/com/tfandkusu/observeroom/MainViewModelTest.kt
+++ b/app/src/test/java/com/tfandkusu/observeroom/MainViewModelTest.kt
@@ -74,7 +74,7 @@ class MainViewModelTest {
             )
         )
         viewModel.progress.value shouldBe true
-        viewModel.onCreate(lifecycleOwner, null).join()
+        viewModel.onCreate(lifecycleOwner, 0).join()
         // リストが更新された
         viewModel.items.value?.get(0)?.id shouldBe 1L
         viewModel.items.value?.get(0)?.memberName shouldBe "name1"
@@ -114,7 +114,7 @@ class MainViewModelTest {
             MemberListItem(1L, "name1", "Sales"),
             MemberListItem(3L, "name2", "Development")
         )
-        viewModel.onCreate(lifecycleOwner, null).join()
+        viewModel.onCreate(lifecycleOwner, 0).join()
         // リストが更新された
         viewModel.items.value?.get(0)?.id shouldBe 1L
         viewModel.items.value?.get(0)?.memberName shouldBe "name1"
@@ -184,7 +184,7 @@ class MainViewModelTest {
         // RxJava版を使う
         viewModel.mode = ObserveMode.RX_JAVA
         viewModel.progress.value shouldBe true
-        viewModel.onCreate(lifecycleOwner, null).join()
+        viewModel.onCreate(lifecycleOwner, 0).join()
         // リストが更新された
         viewModel.items.value?.get(0)?.id shouldBe 1L
         viewModel.items.value?.get(0)?.memberName shouldBe "name1"
@@ -223,7 +223,7 @@ class MainViewModelTest {
             registry.currentState = Lifecycle.State.RESUMED
             viewModel.mode = ObserveMode.LIVE_DATA
             viewModel.progress.value shouldBe true
-            viewModel.onCreate(lifecycleOwner, null).join()
+            viewModel.onCreate(lifecycleOwner, 0).join()
             // リストが更新された
             viewModel.items.value?.get(0)?.id shouldBe 1L
             viewModel.items.value?.get(0)?.memberName shouldBe "name1"


### PR DESCRIPTION
画面回転でFlowオブジェクトが複数生成され、メンバー編集後の一覧更新処理が複数回行われていた。